### PR TITLE
url_for ヘルパから URL 直書きに変更

### DIFF
--- a/app/src/app.go
+++ b/app/src/app.go
@@ -208,7 +208,7 @@ func topHandler(w http.ResponseWriter, r *http.Request) {
 		serverError(w, err)
 		return
 	}
-	prepareHandler(w, r)
+
 	dbConn := <-dbConnPool
 	defer func() {
 		dbConnPool <- dbConn
@@ -266,7 +266,7 @@ func recentHandler(w http.ResponseWriter, r *http.Request) {
 		serverError(w, err)
 		return
 	}
-	prepareHandler(w, r)
+
 	dbConn := <-dbConnPool
 	defer func() {
 		dbConnPool <- dbConn
@@ -329,7 +329,7 @@ func signinHandler(w http.ResponseWriter, r *http.Request) {
 		serverError(w, err)
 		return
 	}
-	prepareHandler(w, r)
+
 	dbConn := <-dbConnPool
 	defer func() {
 		dbConnPool <- dbConn
@@ -352,7 +352,7 @@ func signinPostHandler(w http.ResponseWriter, r *http.Request) {
 		serverError(w, err)
 		return
 	}
-	prepareHandler(w, r)
+
 	dbConn := <-dbConnPool
 	defer func() {
 		dbConnPool <- dbConn
@@ -404,7 +404,7 @@ func signoutHandler(w http.ResponseWriter, r *http.Request) {
 		serverError(w, err)
 		return
 	}
-	prepareHandler(w, r)
+
 	if antiCSRF(w, r, session) {
 		return
 	}
@@ -419,7 +419,7 @@ func mypageHandler(w http.ResponseWriter, r *http.Request) {
 		serverError(w, err)
 		return
 	}
-	prepareHandler(w, r)
+
 	dbConn := <-dbConnPool
 	defer func() {
 		dbConnPool <- dbConn
@@ -457,7 +457,7 @@ func memoHandler(w http.ResponseWriter, r *http.Request) {
 		serverError(w, err)
 		return
 	}
-	prepareHandler(w, r)
+
 	vars := mux.Vars(r)
 	memoId := vars["memo_id"]
 	dbConn := <-dbConnPool
@@ -544,7 +544,7 @@ func memoPostHandler(w http.ResponseWriter, r *http.Request) {
 		serverError(w, err)
 		return
 	}
-	prepareHandler(w, r)
+
 	if antiCSRF(w, r, session) {
 		return
 	}

--- a/app/src/app.go
+++ b/app/src/app.go
@@ -78,9 +78,6 @@ type View struct {
 var (
 	dbConnPool chan *sql.DB
 	fmap       = template.FuncMap{
-		"url_for": func(path string) string {
-			return "http://52.199.202.14" + path
-		},
 		"first_line": func(s string) string {
 			sl := strings.Split(s, "\n")
 			return sl[0]

--- a/app/src/app.go
+++ b/app/src/app.go
@@ -10,7 +10,6 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"net/url"
 	"os"
 	"runtime"
 	"strconv"
@@ -78,10 +77,9 @@ type View struct {
 
 var (
 	dbConnPool chan *sql.DB
-	baseUrl    *url.URL
 	fmap       = template.FuncMap{
 		"url_for": func(path string) string {
-			return baseUrl.String() + path
+			return "http://52.199.202.14" + path
 		},
 		"first_line": func(s string) string {
 			sl := strings.Split(s, "\n")
@@ -156,14 +154,6 @@ func loadConfig(filename string) *Config {
 		os.Exit(1)
 	}
 	return &config
-}
-
-func prepareHandler(w http.ResponseWriter, r *http.Request) {
-	if h := r.Header.Get("X-Forwarded-Host"); h != "" {
-		baseUrl, _ = url.Parse("http://" + h)
-	} else {
-		baseUrl, _ = url.Parse("http://" + r.Host)
-	}
 }
 
 func loadSession(w http.ResponseWriter, r *http.Request) (session *sessions.Session, err error) {

--- a/app/src/templates/base_bottom.html
+++ b/app/src/templates/base_bottom.html
@@ -2,8 +2,8 @@
 
 </div> <!-- /container -->
 
-<script type="text/javascript" src="{{ url_for "/js/jquery.min.js" }}"></script>
-<script type="text/javascript" src="{{ url_for "/js/bootstrap.min.js" }}"></script>
+<script type="text/javascript" src="http://52.199.202.14/js/jquery.min.js"></script>
+<script type="text/javascript" src="http://52.199.202.14/js/bootstrap.min.js"></script>
 </body>
 </html>
 {{ end }}

--- a/app/src/templates/base_bottom.html
+++ b/app/src/templates/base_bottom.html
@@ -2,8 +2,8 @@
 
 </div> <!-- /container -->
 
-<script type="text/javascript" src="http://52.199.202.14/js/jquery.min.js"></script>
-<script type="text/javascript" src="http://52.199.202.14/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="http://localhost/js/jquery.min.js"></script>
+<script type="text/javascript" src="http://localhost/js/bootstrap.min.js"></script>
 </body>
 </html>
 {{ end }}

--- a/app/src/templates/base_top.html
+++ b/app/src/templates/base_top.html
@@ -4,14 +4,14 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html" charset="utf-8">
 <title>Isucon3</title>
-<link rel="stylesheet" href="http://52.199.202.14/css/bootstrap.min.css">
+<link rel="stylesheet" href="http://localhost/css/bootstrap.min.css">
 <style>
 body {
   padding-top: 60px;
 }
 </style>
-<link rel="stylesheet" href="http://52.199.202.14/css/bootstrap-responsive.min.css">
-<link rel="stylesheet" href="http://52.199.202.14/">
+<link rel="stylesheet" href="http://localhost/css/bootstrap-responsive.min.css">
+<link rel="stylesheet" href="http://localhost/">
 </head>
 <body>
 <div class="navbar navbar-fixed-top">
@@ -25,9 +25,9 @@ body {
 <a class="brand" href="/">Isucon3</a>
 <div class="nav-collapse">
 <ul class="nav">
-<li><a href="http://52.199.202.14/">Home</a></li>
+<li><a href="http://localhost/">Home</a></li>
 {{ if .User }}
-<li><a href="http://52.199.202.14/mypage">MyPage</a></li>
+<li><a href="http://localhost/mypage">MyPage</a></li>
 <li>
   <form action="/signout" method="post">
     <input type="hidden" name="sid" value="{{ get_token .Session }}">
@@ -35,7 +35,7 @@ body {
   </form>
 </li>
 {{ else }}
-<li><a href="http://52.199.202.14/signin">SignIn</a></li>
+<li><a href="http://localhost/signin">SignIn</a></li>
 {{ end }}
 </ul>
 </div> <!--/.nav-collapse -->

--- a/app/src/templates/base_top.html
+++ b/app/src/templates/base_top.html
@@ -4,14 +4,14 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html" charset="utf-8">
 <title>Isucon3</title>
-<link rel="stylesheet" href="{{ url_for "/css/bootstrap.min.css" }}">
+<link rel="stylesheet" href="http://52.199.202.14/css/bootstrap.min.css">
 <style>
 body {
   padding-top: 60px;
 }
 </style>
-<link rel="stylesheet" href="{{ url_for "/css/bootstrap-responsive.min.css" }}">
-<link rel="stylesheet" href="{{ url_for "/" }}">
+<link rel="stylesheet" href="http://52.199.202.14/css/bootstrap-responsive.min.css">
+<link rel="stylesheet" href="http://52.199.202.14/">
 </head>
 <body>
 <div class="navbar navbar-fixed-top">
@@ -25,9 +25,9 @@ body {
 <a class="brand" href="/">Isucon3</a>
 <div class="nav-collapse">
 <ul class="nav">
-<li><a href="{{ url_for "/" }}">Home</a></li>
+<li><a href="http://52.199.202.14/">Home</a></li>
 {{ if .User }}
-<li><a href="{{ url_for "/mypage" }}">MyPage</a></li>
+<li><a href="http://52.199.202.14/mypage">MyPage</a></li>
 <li>
   <form action="/signout" method="post">
     <input type="hidden" name="sid" value="{{ get_token .Session }}">
@@ -35,7 +35,7 @@ body {
   </form>
 </li>
 {{ else }}
-<li><a href="{{ url_for "/signin" }}">SignIn</a></li>
+<li><a href="http://52.199.202.14/signin">SignIn</a></li>
 {{ end }}
 </ul>
 </div> <!--/.nav-collapse -->

--- a/app/src/templates/index.html
+++ b/app/src/templates/index.html
@@ -9,7 +9,7 @@
 <ul id="memos">
 {{ range .Memos }}
 <li>
-  <a href="{{ url_for "/memo/" }}{{ .Id }}">{{ first_line .Content }}</a> by {{ .Username }} ({{ .CreatedAt }})
+  <a href="http://52.199.202.14/memo/{{ .Id }}">{{ first_line .Content }}</a> by {{ .Username }} ({{ .CreatedAt }})
 </li>
 {{ end }}
 </ul>

--- a/app/src/templates/index.html
+++ b/app/src/templates/index.html
@@ -9,7 +9,7 @@
 <ul id="memos">
 {{ range .Memos }}
 <li>
-  <a href="http://52.199.202.14/memo/{{ .Id }}">{{ first_line .Content }}</a> by {{ .Username }} ({{ .CreatedAt }})
+  <a href="http://localhost/memo/{{ .Id }}">{{ first_line .Content }}</a> by {{ .Username }} ({{ .CreatedAt }})
 </li>
 {{ end }}
 </ul>

--- a/app/src/templates/memo.html
+++ b/app/src/templates/memo.html
@@ -13,11 +13,11 @@ Memo by {{ .Memo.Username }} ({{ .Memo.CreatedAt }})
 
 <hr>
 {{ if .Older }}
-<a id="older" href="http://52.199.202.14/memo/{{ .Older.Id }}">&lt; older memo</a>
+<a id="older" href="http://localhost/memo/{{ .Older.Id }}">&lt; older memo</a>
 {{ end }}
 |
 {{ if .Newer }}
-<a id="newer" href="http://52.199.202.14/memo/{{ .Newer.Id }}">newer memo &gt;</a>
+<a id="newer" href="http://localhost/memo/{{ .Newer.Id }}">newer memo &gt;</a>
 {{ end }}
 
 <hr>

--- a/app/src/templates/memo.html
+++ b/app/src/templates/memo.html
@@ -13,11 +13,11 @@ Memo by {{ .Memo.Username }} ({{ .Memo.CreatedAt }})
 
 <hr>
 {{ if .Older }}
-<a id="older" href="{{ url_for "/memo/" }}{{ .Older.Id }}">&lt; older memo</a>
+<a id="older" href="http://52.199.202.14/memo/{{ .Older.Id }}">&lt; older memo</a>
 {{ end }}
 |
 {{ if .Newer }}
-<a id="newer" href="{{ url_for "/memo/" }}{{ .Newer.Id }}">newer memo &gt;</a>
+<a id="newer" href="http://52.199.202.14/memo/{{ .Newer.Id }}">newer memo &gt;</a>
 {{ end }}
 
 <hr>

--- a/app/src/templates/mypage.html
+++ b/app/src/templates/mypage.html
@@ -2,7 +2,7 @@
 
 {{ template "base_top" .}}
 
-<form action="{{ url_for "/memo" }}" method="post">
+<form action="http://52.199.202.14/memo" method="post">
   <input type="hidden" name="sid" value="{{ get_token .Session }}">
   <textarea name="content"></textarea>
   <br>
@@ -15,7 +15,7 @@
 <ul>
 {{ range .Memos }}
 <li>
-  <a href="{{ url_for "/memo/" }}{{ .Id }}">{{ first_line .Content }}</a> by {{ .Username }} ({{ .CreatedAt }})
+  <a href="http://52.199.202.14/memo/{{ .Id }}">{{ first_line .Content }}</a> by {{ .Username }} ({{ .CreatedAt }})
   {{ if .IsPrivate }}
   [private]
   {{ end }}

--- a/app/src/templates/mypage.html
+++ b/app/src/templates/mypage.html
@@ -2,7 +2,7 @@
 
 {{ template "base_top" .}}
 
-<form action="http://52.199.202.14/memo" method="post">
+<form action="http://localhost/memo" method="post">
   <input type="hidden" name="sid" value="{{ get_token .Session }}">
   <textarea name="content"></textarea>
   <br>
@@ -15,7 +15,7 @@
 <ul>
 {{ range .Memos }}
 <li>
-  <a href="http://52.199.202.14/memo/{{ .Id }}">{{ first_line .Content }}</a> by {{ .Username }} ({{ .CreatedAt }})
+  <a href="http://localhost/memo/{{ .Id }}">{{ first_line .Content }}</a> by {{ .Username }} ({{ .CreatedAt }})
   {{ if .IsPrivate }}
   [private]
   {{ end }}

--- a/app/src/templates/signin.html
+++ b/app/src/templates/signin.html
@@ -2,7 +2,7 @@
 
 {{ template "base_top" . }}
 
-<form action="{{ url_for "/signin" }}" method="post">
+<form action="http://52.199.202.14/signin" method="post">
 username <input type="text" name="username" size="20">
 <br>
 password <input type="password" name="password" size="20">

--- a/app/src/templates/signin.html
+++ b/app/src/templates/signin.html
@@ -2,7 +2,7 @@
 
 {{ template "base_top" . }}
 
-<form action="http://52.199.202.14/signin" method="post">
+<form action="http://localhost/signin" method="post">
 username <input type="text" name="username" size="20">
 <br>
 password <input type="password" name="password" size="20">


### PR DESCRIPTION
#1 

[ざっくりと #isucon 2013年予選問題の解き方教えます : ISUCON公式Blog#uri_forの呼び出しが多すぎて非効率なのでなんとかする](http://isucon.net/archives/32976287.html#:~:text=uri_for%E3%81%AE%E5%91%BC%E3%81%B3%E5%87%BA%E3%81%97%E3%81%8C%E5%A4%9A%E3%81%99%E3%81%8E%E3%81%A6%E9%9D%9E%E5%8A%B9%E7%8E%87%E3%81%AA%E3%81%AE%E3%81%A7%E3%81%AA%E3%82%93%E3%81%A8%E3%81%8B%E3%81%99%E3%82%8B)