### PR TITLE
/ と /recent にて、先に memos を 100 件絞り込むクエリに修正

### DIFF
--- a/app/src/app.go
+++ b/app/src/app.go
@@ -237,7 +237,7 @@ func topHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	rows.Close()
 
-	rows, err = dbConn.Query("SELECT memos.*, users.username FROM memos USE INDEX (memos_idx_is_private_created_at) JOIN users ON memos.user = users.id WHERE is_private=0 ORDER BY created_at DESC, memos.id DESC LIMIT ?", memosPerPage)
+	rows, err = dbConn.Query("SELECT memos.*, users.username FROM memos JOIN users ON memos.user = users.id JOIN (SELECT id FROM memos WHERE is_private=0 ORDER BY created_at DESC LIMIT ?) AS tmp ON tmp.id = memos.id", memosPerPage)
 	if err != nil {
 		serverError(w, err)
 		return
@@ -291,7 +291,7 @@ func recentHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	rows.Close()
 
-	rows, err = dbConn.Query("SELECT memos.*, users.username FROM memos USE INDEX (memos_idx_is_private_created_at) JOIN users ON memos.user = users.id WHERE is_private=0 ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?", memosPerPage, memosPerPage*page)
+	rows, err = dbConn.Query("SELECT memos.*, users.username FROM memos JOIN users ON memos.user = users.id JOIN (SELECT id FROM memos WHERE is_private=0 ORDER BY created_at DESC LIMIT ? OFFSET ?) AS tmp ON tmp.id = memos.id", memosPerPage, memosPerPage*page)
 	if err != nil {
 		serverError(w, err)
 		return


### PR DESCRIPTION
#1 

[ざっくりと #isucon 2013年予選問題の解き方教えます : ISUCON公式Blog#mysqldが重いのを何とかする(第三段階)](http://isucon.net/archives/32976287.html#:~:text=mysqld%E3%81%8C%E9%87%8D%E3%81%84%E3%81%AE%E3%82%92%E4%BD%95%E3%81%A8%E3%81%8B%E3%81%99%E3%82%8B(%E7%AC%AC%E4%B8%89%E6%AE%B5%E9%9A%8E))